### PR TITLE
Enhance File Preview, Sidebar Navigation, and Storage Footer

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import "@/web/app/globals.css";
 
-import promoImage from "/public/images/preview.png";
+import promoImage from "@/public/images/preview.png";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { ReactQueryProvider } from "@/web/components/providers/query-provider";
 import { Geist, Geist_Mono } from "next/font/google";

--- a/apps/web/components/file-browser/file-preview.tsx
+++ b/apps/web/components/file-browser/file-preview.tsx
@@ -50,11 +50,12 @@ export function FilePreview() {
 		}
 	}, [id, data?.id]);
 
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect(() => {
 		if (data?.type === "folder") {
 			void refetchFolderContents();
 		}
-	}, [data?.type, refetchFolderContents]);
+	}, [data?.type]);
 
 	const handleClose = () => {
 		const params = new URLSearchParams(searchParams.toString());
@@ -137,7 +138,11 @@ export function FilePreview() {
 							</div>
 							<div className="mt-6 pt-6 border-t">
 								<h4 className="font-medium mb-2">Folder Contents</h4>
-								{folderContents && folderContents.length > 0 ? (
+								{folderContentsLoading ? (
+									<div className="flex justify-center p-4">
+										<Loader />
+									</div>
+								) : folderContents && folderContents.length > 0 ? (
 									<div className="space-y-1 max-h-60 overflow-y-auto pr-2">
 										{folderContents.map((item) => (
 											<div key={item.id} className="flex items-center space-x-2 p-2 rounded hover:bg-muted">

--- a/apps/web/components/file-browser/file-preview.tsx
+++ b/apps/web/components/file-browser/file-preview.tsx
@@ -1,13 +1,17 @@
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { createRequest } from "@/web/hooks/createRequest";
-import { FileText, Folder, X } from "lucide-react";
+import { FileText, Folder, X, Image, Video } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { useRequest } from "@/web/hooks/useRequest";
 import type { FileItem } from "@/web/lib/types";
 import { parseError } from "@/web/utils/error";
 import { Loader } from "@/components/loader";
+
+interface FolderContentItem extends FileItem {
+	path?: string;
+}
 
 export function FilePreview() {
 	const router = useRouter();
@@ -25,16 +29,50 @@ export function FilePreview() {
 		manual: true,
 	});
 
+	const fetchFolderContents = createRequest({
+		path: "/files/:id/contents",
+		pathParams: { id },
+	});
+
+	const { 
+		data: folderContents, 
+		isLoading: folderContentsLoading,
+		refetch: refetchFolderContents
+	} = useRequest<FolderContentItem[]>({
+		request: fetchFolderContents,
+		triggers: [id],
+		manual: true
+	});
+
 	useEffect(() => {
 		if (id && id !== data?.id) {
 			void refetch();
 		}
 	}, [id, data?.id]);
 
+	useEffect(() => {
+		if (data?.type === "folder") {
+			void refetchFolderContents();
+		}
+	}, [data?.type, refetchFolderContents]);
+
 	const handleClose = () => {
 		const params = new URLSearchParams(searchParams.toString());
 		params.delete("id");
 		router.replace(`?${params.toString()}`);
+	};
+
+	const getFileIcon = (type: string) => {
+		switch(type) {
+			case "folder":
+				return <Folder className="h-4 w-4 text-muted-foreground" />;
+			case "image":
+				return <Image className="h-4 w-4 text-muted-foreground" />;
+			case "video":
+				return <Video className="h-4 w-4 text-muted-foreground" />;
+			default:
+				return <FileText className="h-4 w-4 text-muted-foreground" />;
+		}
 	};
 
 	return (
@@ -87,10 +125,36 @@ export function FilePreview() {
 								</div>
 							</div>
 						</div>
+					) : data?.type === "folder" ? (
+						<div className="border rounded-md p-4 bg-muted/30">
+							<div className="aspect-[4/3] bg-background rounded-md border flex items-center justify-center mb-4">
+								<Folder className="h-16 w-16 text-muted-foreground" />
+							</div>
+							<div className="space-y-2">
+								<h3 className="font-medium">{data?.name}</h3>
+								<p className="text-sm text-muted-foreground">Last modified: {data?.modified}</p>
+								{data?.size && <p className="text-sm text-muted-foreground">Total size: {data?.size}</p>}
+							</div>
+							<div className="mt-6 pt-6 border-t">
+								<h4 className="font-medium mb-2">Folder Contents</h4>
+								{folderContents && folderContents.length > 0 ? (
+									<div className="space-y-1 max-h-60 overflow-y-auto pr-2">
+										{folderContents.map((item) => (
+											<div key={item.id} className="flex items-center space-x-2 p-2 rounded hover:bg-muted">
+												{getFileIcon(item.type)}
+												<span className="text-sm truncate">{item.name}</span>
+											</div>
+										))}
+									</div>
+								) : (
+									<p className="text-sm text-muted-foreground p-2">This folder is empty</p>
+								)}
+							</div>
+						</div>
 					) : (
 						<div className="text-center py-8 text-muted-foreground">
 							<Folder className="h-12 w-12 mx-auto mb-2" />
-							<p>Folder preview not available</p>
+							<p>Preview not available</p>
 						</div>
 					)}
 				</div>

--- a/apps/web/components/main-sidebar/sidebar-folders.tsx
+++ b/apps/web/components/main-sidebar/sidebar-folders.tsx
@@ -11,7 +11,6 @@ import {
 	SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 const folders = [
 	{
@@ -61,33 +60,27 @@ export default function SidebarFolders() {
 						{folders.map(folder => (
 							<Collapsible key={folder.name} className="group/collapsible">
 								<SidebarMenuItem>
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<CollapsibleTrigger asChild>
-													<SidebarMenuButton>
-														<folder.icon className="size-4" />
-														<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
-														{folder.subfolders && (
-															<ChevronDown className="ml-1 size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
-														)}
-														<span className="ml-auto text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">{folder.count}</span>
-													</SidebarMenuButton>
-												</CollapsibleTrigger>
-											</TooltipTrigger>
-											<TooltipContent side="right" className="group-data-[collapsible=open]:hidden">
-												<p className="font-semibold">{folder.name} ({folder.count})</p>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
+									<CollapsibleTrigger asChild>
+										<SidebarMenuButton className="px-3" tooltip={`${folder.name} (${folder.count})`}>
+											<folder.icon className="size-4" />
+											<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
+											<span className="ml-1 text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">
+												{folder.count}
+											</span>
+											{folder.subfolders && (
+												<ChevronDown className="ml-auto size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
+											)}
+										</SidebarMenuButton>
+									</CollapsibleTrigger>
+
 									{folder.subfolders && (
 										<CollapsibleContent>
-											<SidebarMenuSub>
+											<SidebarMenuSub className="group-data-[collapsible=icon]:hidden">
 												{folder.subfolders.map(subfolder => (
 													<SidebarMenuSubItem key={subfolder.name}>
 														<SidebarMenuSubButton className="w-full">
 															<span>{subfolder.name}</span>
-															<span className="ml-auto text-xs text-sidebar-foreground/70">{subfolder.count}</span>
+															<span className="ml-1 text-xs text-sidebar-foreground/70">{subfolder.count}</span>
 														</SidebarMenuSubButton>
 													</SidebarMenuSubItem>
 												))}

--- a/apps/web/components/main-sidebar/sidebar-folders.tsx
+++ b/apps/web/components/main-sidebar/sidebar-folders.tsx
@@ -82,7 +82,7 @@ export default function SidebarFolders() {
 									</TooltipProvider>
 									{folder.subfolders && (
 										<CollapsibleContent>
-											<SidebarMenuSub className="!px-0 !mx-0 ml-3.5">
+											<SidebarMenuSub>
 												{folder.subfolders.map(subfolder => (
 													<SidebarMenuSubItem key={subfolder.name}>
 														<SidebarMenuSubButton className="w-full">

--- a/apps/web/components/main-sidebar/sidebar-folders.tsx
+++ b/apps/web/components/main-sidebar/sidebar-folders.tsx
@@ -11,6 +11,7 @@ import {
 	SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 const folders = [
 	{
@@ -60,16 +61,25 @@ export default function SidebarFolders() {
 						{folders.map(folder => (
 							<Collapsible key={folder.name} className="group/collapsible">
 								<SidebarMenuItem>
-									<CollapsibleTrigger asChild>
-										<SidebarMenuButton>
-											<folder.icon className="size-4" />
-											<span>{folder.name}</span>
-											<span className="ml-auto text-xs text-sidebar-foreground/70">{folder.count}</span>
-											{folder.subfolders && (
-												<ChevronDown className="ml-1 size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
-											)}
-										</SidebarMenuButton>
-									</CollapsibleTrigger>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<CollapsibleTrigger asChild>
+													<SidebarMenuButton>
+														<folder.icon className="size-4" />
+														<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
+														<span className="ml-auto text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">{folder.count}</span>
+														{folder.subfolders && (
+															<ChevronDown className="ml-1 size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
+														)}
+													</SidebarMenuButton>
+												</CollapsibleTrigger>
+											</TooltipTrigger>
+											<TooltipContent side="right" className="group-data-[collapsible=open]:hidden">
+												<p className="font-semibold">{folder.name} ({folder.count})</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
 									{folder.subfolders && (
 										<CollapsibleContent>
 											<SidebarMenuSub>

--- a/apps/web/components/main-sidebar/sidebar-folders.tsx
+++ b/apps/web/components/main-sidebar/sidebar-folders.tsx
@@ -68,10 +68,10 @@ export default function SidebarFolders() {
 													<SidebarMenuButton>
 														<folder.icon className="size-4" />
 														<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
-														<span className="ml-auto text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">{folder.count}</span>
 														{folder.subfolders && (
 															<ChevronDown className="ml-1 size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
 														)}
+														<span className="ml-auto text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">{folder.count}</span>
 													</SidebarMenuButton>
 												</CollapsibleTrigger>
 											</TooltipTrigger>
@@ -82,10 +82,10 @@ export default function SidebarFolders() {
 									</TooltipProvider>
 									{folder.subfolders && (
 										<CollapsibleContent>
-											<SidebarMenuSub>
+											<SidebarMenuSub className="!px-0 !mx-0 ml-3.5">
 												{folder.subfolders.map(subfolder => (
 													<SidebarMenuSubItem key={subfolder.name}>
-														<SidebarMenuSubButton>
+														<SidebarMenuSubButton className="w-full">
 															<span>{subfolder.name}</span>
 															<span className="ml-auto text-xs text-sidebar-foreground/70">{subfolder.count}</span>
 														</SidebarMenuSubButton>

--- a/apps/web/components/main-sidebar/sidebar-footer.tsx
+++ b/apps/web/components/main-sidebar/sidebar-footer.tsx
@@ -3,7 +3,7 @@ import { Progress } from "@/components/ui/progress";
 import { SidebarFooter } from "@/components/ui/sidebar";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
-// TODO: Get actualy data from api, fix collapsed styling
+// TODO: Get actual data from api, fix collapsed styling
 export default function StorageFooter() {
 	const storageUsed = 69;
 	return (

--- a/apps/web/components/main-sidebar/sidebar-footer.tsx
+++ b/apps/web/components/main-sidebar/sidebar-footer.tsx
@@ -1,14 +1,16 @@
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { SidebarFooter } from "@/components/ui/sidebar";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 // TODO: Get actualy data from api, fix collapsed styling
 export default function StorageFooter() {
 	const storageUsed = 69;
 	return (
-		<SidebarFooter>
-			<div className="p-2">
-				<div className="rounded-lg bg-sidebar-accent p-3">
+		<SidebarFooter className="transition-all duration-200 ease-linear">
+			<div className="p-2 group-data-[collapsible=icon]:p-0 transition-all duration-200 ease-linear">
+				{/* Standard view - shown when expanded */}
+				<div className="rounded-lg bg-sidebar-accent p-3 transition-opacity duration-200 ease-linear opacity-100 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:hidden">
 					<div className="flex items-center justify-between text-sm font-medium">
 						<span>Storage</span>
 						<span>{storageUsed}% used</span>
@@ -21,6 +23,21 @@ export default function StorageFooter() {
 						</Button>
 					</div>
 				</div>
+				
+				{/* Circular view - shown when collapsed with tooltip */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div className="hidden group-data-[collapsible=icon]:flex transition-opacity duration-200 ease-linear opacity-0 group-data-[collapsible=icon]:opacity-100 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-sidebar-accent group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:items-center">
+							<svg className="group-data-[collapsible=icon]:size-6 -rotate-90" viewBox="0 0 48 48">
+								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="4" pathLength="100" />
+								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeWidth="4" pathLength="100" strokeDasharray={`${storageUsed} 100`} />
+							</svg>
+						</div>
+					</TooltipTrigger>
+					<TooltipContent side="right" sideOffset={4}>
+						<span className="text-xs">{storageUsed}% used</span>
+					</TooltipContent>
+				</Tooltip>
 			</div>
 		</SidebarFooter>
 	);

--- a/apps/web/components/main-sidebar/sidebar-footer.tsx
+++ b/apps/web/components/main-sidebar/sidebar-footer.tsx
@@ -1,44 +1,98 @@
-import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
-import { SidebarFooter } from "@/components/ui/sidebar";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { ChevronDown, Folder, ImageIcon, Video, Music, Archive } from "lucide-react";
+import {
+	SidebarGroup,
+	SidebarGroupContent,
+	SidebarGroupLabel,
+	SidebarMenu,
+	SidebarMenuItem,
+	SidebarMenuButton,
+	SidebarMenuSub,
+	SidebarMenuSubButton,
+	SidebarMenuSubItem,
+} from "@/components/ui/sidebar";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
-// TODO: Get actual data from api, fix collapsed styling
-export default function StorageFooter() {
-	const storageUsed = 69;
+const folders = [
+	{
+		name: "Documents",
+		icon: Folder,
+		count: 24,
+		subfolders: [
+			{ name: "Work", count: 12 },
+			{ name: "Personal", count: 8 },
+			{ name: "Archive", count: 4 },
+		],
+	},
+	{
+		name: "Images",
+		icon: ImageIcon,
+		count: 156,
+		subfolders: [
+			{ name: "Screenshots", count: 45 },
+			{ name: "Photos", count: 89 },
+			{ name: "Graphics", count: 22 },
+		],
+	},
+	{
+		name: "Videos",
+		icon: Video,
+		count: 8,
+	},
+	{
+		name: "Music",
+		icon: Music,
+		count: 32,
+	},
+	{
+		name: "Archives",
+		icon: Archive,
+		count: 5,
+	},
+];
+
+export default function SidebarFolders() {
 	return (
-		<SidebarFooter className="transition-all duration-200 ease-linear">
-			<div className="p-2 group-data-[collapsible=icon]:p-0 transition-all duration-200 ease-linear">
-				{/* Standard view - shown when expanded */}
-				<div className="rounded-lg bg-sidebar-accent p-3 transition-opacity duration-200 ease-linear opacity-100 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:hidden">
-					<div className="flex items-center justify-between text-sm font-medium">
-						<span>Storage</span>
-						<span>{storageUsed}% used</span>
-					</div>
-					<Progress value={storageUsed} className="mt-2 h-2" />
-					<div className="mt-2 flex justify-between text-xs text-sidebar-foreground/70">
-						<span>6.9 GB of 10 GB used</span>
-						<Button variant="link" size="sm" className="h-auto p-0 text-xs">
-							Upgrade
-						</Button>
-					</div>
-				</div>
-				
-				{/* Circular view - shown when collapsed with tooltip */}
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<div className="hidden group-data-[collapsible=icon]:flex transition-opacity duration-200 ease-linear opacity-0 group-data-[collapsible=icon]:opacity-100 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-sidebar-accent group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:items-center">
-							<svg className="group-data-[collapsible=icon]:size-6 -rotate-90" viewBox="0 0 48 48">
-								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="4" pathLength="100" />
-								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeWidth="4" pathLength="100" strokeDasharray={`${storageUsed} 100`} />
-							</svg>
-						</div>
-					</TooltipTrigger>
-					<TooltipContent side="right" sideOffset={4}>
-						<span className="text-xs">{storageUsed}% used</span>
-					</TooltipContent>
-				</Tooltip>
-			</div>
-		</SidebarFooter>
+		<>
+			<SidebarGroup>
+				<SidebarGroupLabel>Folders</SidebarGroupLabel>
+				<SidebarGroupContent>
+					<SidebarMenu>
+						{folders.map(folder => (
+							<Collapsible key={folder.name} className="group/collapsible">
+								<SidebarMenuItem>
+									<CollapsibleTrigger asChild>
+										<SidebarMenuButton className="px-3" tooltip={`${folder.name} (${folder.count})`}>
+											<folder.icon className="size-4" />
+											<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
+											<span className="ml-1 text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">
+												{folder.count}
+											</span>
+											{folder.subfolders && (
+												<ChevronDown className="ml-auto size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
+											)}
+										</SidebarMenuButton>
+									</CollapsibleTrigger>
+
+									{folder.subfolders && (
+										<CollapsibleContent>
+											<SidebarMenuSub className="group-data-[collapsible=icon]:hidden">
+												{folder.subfolders.map(subfolder => (
+													<SidebarMenuSubItem key={subfolder.name}>
+														<SidebarMenuSubButton className="w-full">
+															<span>{subfolder.name}</span>
+															<span className="ml-1 text-xs text-sidebar-foreground/70">{subfolder.count}</span>
+														</SidebarMenuSubButton>
+													</SidebarMenuSubItem>
+												))}
+											</SidebarMenuSub>
+										</CollapsibleContent>
+									)}
+								</SidebarMenuItem>
+							</Collapsible>
+						))}
+					</SidebarMenu>
+				</SidebarGroupContent>
+			</SidebarGroup>
+		</>
 	);
 }

--- a/apps/web/components/main-sidebar/sidebar-footer.tsx
+++ b/apps/web/components/main-sidebar/sidebar-footer.tsx
@@ -1,98 +1,44 @@
-import { ChevronDown, Folder, ImageIcon, Video, Music, Archive } from "lucide-react";
-import {
-	SidebarGroup,
-	SidebarGroupContent,
-	SidebarGroupLabel,
-	SidebarMenu,
-	SidebarMenuItem,
-	SidebarMenuButton,
-	SidebarMenuSub,
-	SidebarMenuSubButton,
-	SidebarMenuSubItem,
-} from "@/components/ui/sidebar";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { SidebarFooter } from "@/components/ui/sidebar";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
-const folders = [
-	{
-		name: "Documents",
-		icon: Folder,
-		count: 24,
-		subfolders: [
-			{ name: "Work", count: 12 },
-			{ name: "Personal", count: 8 },
-			{ name: "Archive", count: 4 },
-		],
-	},
-	{
-		name: "Images",
-		icon: ImageIcon,
-		count: 156,
-		subfolders: [
-			{ name: "Screenshots", count: 45 },
-			{ name: "Photos", count: 89 },
-			{ name: "Graphics", count: 22 },
-		],
-	},
-	{
-		name: "Videos",
-		icon: Video,
-		count: 8,
-	},
-	{
-		name: "Music",
-		icon: Music,
-		count: 32,
-	},
-	{
-		name: "Archives",
-		icon: Archive,
-		count: 5,
-	},
-];
-
-export default function SidebarFolders() {
+// TODO: Get actual data from api, fix collapsed styling
+export default function StorageFooter() {
+	const storageUsed = 69;
 	return (
-		<>
-			<SidebarGroup>
-				<SidebarGroupLabel>Folders</SidebarGroupLabel>
-				<SidebarGroupContent>
-					<SidebarMenu>
-						{folders.map(folder => (
-							<Collapsible key={folder.name} className="group/collapsible">
-								<SidebarMenuItem>
-									<CollapsibleTrigger asChild>
-										<SidebarMenuButton className="px-3" tooltip={`${folder.name} (${folder.count})`}>
-											<folder.icon className="size-4" />
-											<span className="group-data-[collapsible=icon]:sr-only">{folder.name}</span>
-											<span className="ml-1 text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:sr-only">
-												{folder.count}
-											</span>
-											{folder.subfolders && (
-												<ChevronDown className="ml-auto size-4 transition-transform duration-300 group-data-[state=open]/collapsible:rotate-180" />
-											)}
-										</SidebarMenuButton>
-									</CollapsibleTrigger>
-
-									{folder.subfolders && (
-										<CollapsibleContent>
-											<SidebarMenuSub className="group-data-[collapsible=icon]:hidden">
-												{folder.subfolders.map(subfolder => (
-													<SidebarMenuSubItem key={subfolder.name}>
-														<SidebarMenuSubButton className="w-full">
-															<span>{subfolder.name}</span>
-															<span className="ml-1 text-xs text-sidebar-foreground/70">{subfolder.count}</span>
-														</SidebarMenuSubButton>
-													</SidebarMenuSubItem>
-												))}
-											</SidebarMenuSub>
-										</CollapsibleContent>
-									)}
-								</SidebarMenuItem>
-							</Collapsible>
-						))}
-					</SidebarMenu>
-				</SidebarGroupContent>
-			</SidebarGroup>
-		</>
+		<SidebarFooter className="transition-all duration-200 ease-linear">
+			<div className="p-2 group-data-[collapsible=icon]:p-0 transition-all duration-200 ease-linear">
+				{/* Standard view - shown when expanded */}
+				<div className="rounded-lg bg-sidebar-accent p-3 transition-opacity duration-200 ease-linear opacity-100 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:hidden">
+					<div className="flex items-center justify-between text-sm font-medium">
+						<span>Storage</span>
+						<span>{storageUsed}% used</span>
+					</div>
+					<Progress value={storageUsed} className="mt-2 h-2" />
+					<div className="mt-2 flex justify-between text-xs text-sidebar-foreground/70">
+						<span>6.9 GB of 10 GB used</span>
+						<Button variant="link" size="sm" className="h-auto p-0 text-xs">
+							Upgrade
+						</Button>
+					</div>
+				</div>
+				
+				{/* Circular view - shown when collapsed with tooltip */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div className="hidden group-data-[collapsible=icon]:flex transition-opacity duration-200 ease-linear opacity-0 group-data-[collapsible=icon]:opacity-100 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:relative group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:bg-sidebar-accent group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:items-center">
+							<svg className="group-data-[collapsible=icon]:size-6 -rotate-90" viewBox="0 0 48 48">
+								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeOpacity="0.2" strokeWidth="4" pathLength="100" />
+								<circle cx="24" cy="24" r="20" fill="none" stroke="currentColor" strokeWidth="4" pathLength="100" strokeDasharray={`${storageUsed} 100`} />
+							</svg>
+						</div>
+					</TooltipTrigger>
+					<TooltipContent side="right" sideOffset={4}>
+						<span className="text-xs">{storageUsed}% used</span>
+					</TooltipContent>
+				</Tooltip>
+			</div>
+		</SidebarFooter>
 	);
 }

--- a/apps/web/components/main-sidebar/tag-menu.tsx
+++ b/apps/web/components/main-sidebar/tag-menu.tsx
@@ -16,7 +16,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const tags = [
 	{ name: "Important", color: "bg-red-500", count: 12 },
@@ -32,7 +31,7 @@ export default function TagMenu() {
 		<SidebarGroup>
 			<SidebarGroupLabel>
 				Tags
-				<Button variant="ghost" size="icon" className="ml-auto h-6 w-6 pl-4">
+				<Button variant="ghost" size="icon" className="ml-auto h-6 w-6 ">
 					<Plus className="size-3" />
 					<span className="sr-only">Add Tag</span>
 				</Button>
@@ -40,45 +39,33 @@ export default function TagMenu() {
 			<SidebarGroupContent>
 				<SidebarMenu>
 					{tags.map(tag => (
-						<SidebarMenuItem key={tag.name}>
-							<TooltipProvider>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<div className="relative flex items-center w-full group">
-											<SidebarMenuButton className="flex-1 pr-10">
-												<span className={`size-3 rounded-full ${tag.color} group-data-[collapsible=icon]:mx-auto`} />
-												<span className="group-data-[collapsible=icon]:hidden">{tag.name}</span>
-											</SidebarMenuButton>
-											<span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-sidebar-foreground/70 group-hover:hidden group-data-[collapsible=icon]:hidden">
-												{tag.count}
-											</span>
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button
-														variant="ghost"
-														size="sm"
-														className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 group-data-[collapsible=icon]:hidden"
-													>
-														<MoreHorizontal className="size-3" />
-														<span className="sr-only">Tag options</span>
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuItem>Edit Tag</DropdownMenuItem>
-													<DropdownMenuItem>Change Color</DropdownMenuItem>
-													<DropdownMenuSeparator />
-													<DropdownMenuItem className="text-destructive">Delete Tag</DropdownMenuItem>
-												</DropdownMenuContent>
-											</DropdownMenu>
+						<SidebarMenuItem key={tag.name} className="group/item">
+							<SidebarMenuButton
+								className="flex items-center w-full peer pl-3 group-data-[collapsible=icon]:justify-center justify-between"
+								tooltip={`${tag.name} (${tag.count})`}
+							>
+								<div className="flex items-center gap-1">
+									<span className={`size-3 rounded-full ${tag.color}`} />
+									<span className="ml-2 group-data-[collapsible=icon]:hidden">{tag.name}</span>
+									<span className="ml-2 text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:hidden">
+										{tag.count}
+									</span>
+								</div>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<div className="px-1.5 opacity-0 group-hover/item:opacity-100 group-data-[collapsible=icon]:hidden">
+											<MoreHorizontal className="size-3" />
+											<span className="sr-only">Tag options</span>
 										</div>
-									</TooltipTrigger>
-									<TooltipContent side="right" className="group-data-[collapsible=open]:hidden">
-										<p className="font-semibold">
-											{tag.name} ({tag.count})
-										</p>
-									</TooltipContent>
-								</Tooltip>
-							</TooltipProvider>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="end">
+										<DropdownMenuItem>Edit Tag</DropdownMenuItem>
+										<DropdownMenuItem>Change Color</DropdownMenuItem>
+										<DropdownMenuSeparator />
+										<DropdownMenuItem className="text-destructive">Delete Tag</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+							</SidebarMenuButton>
 						</SidebarMenuItem>
 					))}
 				</SidebarMenu>

--- a/apps/web/components/main-sidebar/tag-menu.tsx
+++ b/apps/web/components/main-sidebar/tag-menu.tsx
@@ -32,7 +32,7 @@ export default function TagMenu() {
 		<SidebarGroup>
 			<SidebarGroupLabel>
 				Tags
-				<Button variant="ghost" size="icon" className="ml-auto h-6 w-6 p-0">
+				<Button variant="ghost" size="icon" className="ml-auto h-6 w-6 pl-4">
 					<Plus className="size-3" />
 					<span className="sr-only">Add Tag</span>
 				</Button>
@@ -44,20 +44,20 @@ export default function TagMenu() {
 							<TooltipProvider>
 								<Tooltip>
 									<TooltipTrigger asChild>
-										<div className="flex items-center w-full group">
-											<SidebarMenuButton className="flex-1">
+										<div className="relative flex items-center w-full group">
+											<SidebarMenuButton className="flex-1 pr-10">
 												<span className={`size-3 rounded-full ${tag.color} group-data-[collapsible=icon]:mx-auto`} />
 												<span className="group-data-[collapsible=icon]:hidden">{tag.name}</span>
-												<span className="ml-auto text-xs text-sidebar-foreground/70 group-data-[collapsible=icon]:hidden">
-													{tag.count}
-												</span>
 											</SidebarMenuButton>
+											<span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-sidebar-foreground/70 group-hover:hidden group-data-[collapsible=icon]:hidden">
+												{tag.count}
+											</span>
 											<DropdownMenu>
 												<DropdownMenuTrigger asChild>
 													<Button
 														variant="ghost"
 														size="sm"
-														className="ml-1 h-6 w-6 p-0 opacity-0 group-hover:opacity-100 group-data-[collapsible=icon]:hidden"
+														className="absolute right-3 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 group-data-[collapsible=icon]:hidden"
 													>
 														<MoreHorizontal className="size-3" />
 														<span className="sr-only">Tag options</span>

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -603,7 +603,7 @@ function SidebarMenuSub({ className, ...props }: ComponentProps<"ul">) {
 			data-slot="sidebar-menu-sub"
 			data-sidebar="menu-sub"
 			className={cn(
-				"border-sidebar-border flex min-w-0 translate-x-px flex-col gap-1 border-l ml-3.5",
+				"border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
 				"group-data-[collapsible=icon]:hidden",
 				className
 			)}

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -603,7 +603,7 @@ function SidebarMenuSub({ className, ...props }: ComponentProps<"ul">) {
 			data-slot="sidebar-menu-sub"
 			data-sidebar="menu-sub"
 			className={cn(
-				"border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+				"border-sidebar-border flex min-w-0 translate-x-px flex-col gap-1 border-l ml-3.5",
 				"group-data-[collapsible=icon]:hidden",
 				className
 			)}


### PR DESCRIPTION
## Summary
This PR enhances the folder preview functionality with folder content display, improves the sidebar's folder structure and storage footer with smooth transitions and tooltips, and refines the tag menu UI for better usability and consistency.

## Changes

1. **File Preview Component**
   - Added folder preview with contents listing
   - Implemented file type icons (folder, image, video, document)
   - Fetches and displays folder contents when a folder is selected
   - Shows file metadata including modification date and size
   - Improved empty state messaging for better UX

2. **Sidebar Folders Component**
   - Rearranged UI elements for better visual hierarchy (chevron before count)
   - Added proper indentation for subfolder menus with `ml-3.5` and removed default padding
   - Improved width handling with `w-full` on submenu buttons for better click targets
   - Wrapped each folder trigger in a `Tooltip` to display folder names and counts on hover in collapsed mode, mirroring TagMenu behavior

3. **Tag Menu Refinements**
   - Repositioned count indicators and action buttons with absolute positioning
   - Improved hover state interactions with better visibility toggle
   - Adjusted padding for the Add Tag button

4. **Storage Footer**
   - Completely hides the expanded view when collapsed to eliminate extra padding
   - Added `transition-all` and `opacity` animations on expand/collapse for a smooth cross-fade
   - Renders a circular SVG progress ring in collapsed mode, matching the `size-8` icon container
   - Wrapped the ring in a tooltip displaying `{storageUsed}% used` on hover
   - Ensured all sizing uses Tailwind `size-N` utilities instead of hardcoded values
   - Unified animation durations (`200ms ease-linear`) to match other sidebar components

## Screenshots
**Folder Preview**  
![image](https://github.com/user-attachments/assets/ef8ed88c-3934-4a3c-8c61-40c81fe9b81d)

**Sidebar Folders and Tag Menu**  
![image](https://github.com/user-attachments/assets/ba839710-d985-446c-ae08-e40ba79a9ec9)

**Storage Footer - Expanded → Collapsed Transition**  
![storage-footer-transition.gif](https://github.com/user-attachments/assets/468c4566-730b-47e8-aac0-052deef089e4)

**Tooltip on Collapsed Footer**  
![footer-tooltip.png](https://github.com/user-attachments/assets/b0dd2635-3c3f-426c-a5bb-f18c9458529c)

**Folder Tooltips**  
![folder-tooltip.png](https://github.com/user-attachments/assets/42267d9c-77eb-4adb-8e0a-67e4534c907f)