### PR TITLE
fix: hydration error due to theme provider.

### DIFF
--- a/apps/web/app/(app)/app/layout.tsx
+++ b/apps/web/app/(app)/app/layout.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import "@/web/app/globals.css";
 import { Inter } from "next/font/google";
 
-import { ThemeProvider } from "@/components/providers/theme-provider";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/main-sidebar/app-sidebar";
 
@@ -12,14 +11,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body className={inter.className}>
-				<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-					<SidebarProvider>
-						<AppSidebar variant="inset" />
-						<SidebarInset className="md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
-							<main className="flex-1 p-1">{children}</main>
-						</SidebarInset>
-					</SidebarProvider>
-				</ThemeProvider>
+				<SidebarProvider>
+					<AppSidebar variant="inset" />
+					<SidebarInset className="md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0">
+						<main className="flex-1 p-1">{children}</main>
+					</SidebarInset>
+				</SidebarProvider>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
There was a hydration error because the ThemeProvider was being wrapped multiple times, both in the root layout and the app layout. Removing the duplicate wrapping resolved the issue.

<img width="971" alt="Screenshot 2025-06-06 at 6 23 26 PM" src="https://github.com/user-attachments/assets/f57d77a2-5340-40d1-944f-1c1f1b078d3d" />
