### PR TITLE
style(header): unify header icons with AnimateIcon and muted foreground styling

### DIFF
--- a/apps/web/components/animate-ui/icons/bell.tsx
+++ b/apps/web/components/animate-ui/icons/bell.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+import { motion, type Variants } from "motion/react";
+
+import { getVariants, useAnimateIconContext, IconWrapper, type IconProps } from "@/components/animate-ui/icons/icon";
+
+type BellProps = IconProps<keyof typeof animations>;
+
+const animations = {
+	default: {
+		group: {
+			initial: {
+				rotate: 0,
+			},
+			animate: {
+				rotate: [0, 20, -10, 10, -5, 3, 0],
+				transformOrigin: "top center",
+				transition: { duration: 0.9, ease: "easeInOut" },
+			},
+		},
+		path1: {
+			initial: {
+				x: 0,
+			},
+			animate: {
+				x: [0, -6, 5, -5, 4, -3, 2, 0],
+				transition: { duration: 1.1, ease: "easeInOut" },
+			},
+		},
+		path2: {},
+	} satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: BellProps) {
+	const { controls } = useAnimateIconContext();
+	const variants = getVariants(animations);
+
+	return (
+		<motion.svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			variants={variants.group}
+			initial="initial"
+			animate={controls}
+			{...props}
+		>
+			<motion.path d="M10.268 21a2 2 0 0 0 3.464 0" variants={variants.path1} initial="initial" animate={controls} />
+			<motion.path
+				d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
+				variants={variants.path2}
+				initial="initial"
+				animate={controls}
+			/>
+		</motion.svg>
+	);
+}
+
+function Bell(props: BellProps) {
+	return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export { animations, Bell, Bell as BellIcon, type BellProps, type BellProps as BellIconProps };

--- a/apps/web/components/animate-ui/icons/icon.tsx
+++ b/apps/web/components/animate-ui/icons/icon.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import * as React from "react";
+import { SVGMotionProps, useAnimation, type AnimationControls, type Variants } from "motion/react";
+
+import { cn } from "@/web/lib/utils";
+
+const staticAnimations = {
+	path: {
+		initial: { pathLength: 1, opacity: 1 },
+		animate: {
+			pathLength: [0.05, 1],
+			opacity: [0, 1],
+			transition: {
+				duration: 0.8,
+				ease: "easeInOut",
+				opacity: { duration: 0.01 },
+			},
+		},
+	} as Variants,
+	"path-loop": {
+		initial: { pathLength: 1, opacity: 1 },
+		animate: {
+			pathLength: [1, 0.05, 1],
+			opacity: [1, 0, 1],
+			transition: {
+				duration: 1.6,
+				ease: "easeInOut",
+				opacity: { duration: 0.01 },
+			},
+		},
+	} as Variants,
+} as const;
+
+type StaticAnimations = keyof typeof staticAnimations;
+type TriggerProp<T = string> = boolean | StaticAnimations | T;
+
+interface AnimateIconContextValue {
+	controls: AnimationControls | undefined;
+	animation: StaticAnimations | string;
+	loop: boolean;
+	loopDelay: number;
+}
+
+interface DefaultIconProps<T = string> {
+	animate?: TriggerProp<T>;
+	onAnimateChange?: (value: boolean, animation: StaticAnimations | string) => void;
+	animateOnHover?: TriggerProp<T>;
+	animateOnTap?: TriggerProp<T>;
+	animation?: T | StaticAnimations;
+	loop?: boolean;
+	loopDelay?: number;
+	onAnimateStart?: () => void;
+	onAnimateEnd?: () => void;
+}
+
+interface AnimateIconProps<T = string> extends DefaultIconProps<T> {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	children: React.ReactElement<any, any>;
+}
+
+interface IconProps<T>
+	extends DefaultIconProps<T>,
+		Omit<SVGMotionProps<SVGSVGElement>, "animate" | "onAnimationStart" | "onAnimationEnd"> {
+	size?: number;
+}
+
+interface IconWrapperProps<T> extends IconProps<T> {
+	icon: React.ComponentType<IconProps<T>>;
+}
+
+const AnimateIconContext = React.createContext<AnimateIconContextValue | null>(null);
+
+function useAnimateIconContext() {
+	const context = React.useContext(AnimateIconContext);
+	if (!context)
+		return {
+			controls: undefined,
+			animation: "default",
+			loop: false,
+			loopDelay: 0,
+		};
+	return context;
+}
+
+function AnimateIcon({
+	animate,
+	onAnimateChange,
+	animateOnHover,
+	animateOnTap,
+	animation = "default",
+	loop = false,
+	loopDelay = 0,
+	onAnimateStart,
+	onAnimateEnd,
+	children,
+}: AnimateIconProps) {
+	const controls = useAnimation();
+	const [localAnimate, setLocalAnimate] = React.useState(!!animate);
+	const currentAnimation = React.useRef(animation);
+
+	const startAnimation = React.useCallback(
+		(trigger: TriggerProp) => {
+			currentAnimation.current = typeof trigger === "string" ? trigger : animation;
+			setLocalAnimate(true);
+		},
+		[animation]
+	);
+
+	const stopAnimation = React.useCallback(() => {
+		setLocalAnimate(false);
+	}, []);
+
+	React.useEffect(() => {
+		currentAnimation.current = typeof animate === "string" ? animate : animation;
+		setLocalAnimate(!!animate);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [animate]);
+
+	React.useEffect(() => onAnimateChange?.(localAnimate, currentAnimation.current), [localAnimate, onAnimateChange]);
+
+	React.useEffect(() => {
+		if (localAnimate) onAnimateStart?.();
+		void controls.start(localAnimate ? "animate" : "initial").then(() => {
+			if (localAnimate) onAnimateEnd?.();
+		});
+	}, [localAnimate, controls, onAnimateStart, onAnimateEnd]);
+
+	const handleMouseEnter = (e: MouseEvent) => {
+		if (animateOnHover) startAnimation(animateOnHover);
+		children.props?.onMouseEnter?.(e);
+	};
+	const handleMouseLeave = (e: MouseEvent) => {
+		if (animateOnHover || animateOnTap) stopAnimation();
+		children.props?.onMouseLeave?.(e);
+	};
+	const handlePointerDown = (e: PointerEvent) => {
+		if (animateOnTap) startAnimation(animateOnTap);
+		children.props?.onPointerDown?.(e);
+	};
+	const handlePointerUp = (e: PointerEvent) => {
+		if (animateOnTap) stopAnimation();
+		children.props?.onPointerUp?.(e);
+	};
+
+	const child = React.Children.only(children);
+	const cloned = React.cloneElement(child, {
+		onMouseEnter: handleMouseEnter,
+		onMouseLeave: handleMouseLeave,
+		onPointerDown: handlePointerDown,
+		onPointerUp: handlePointerUp,
+	});
+
+	return (
+		<AnimateIconContext.Provider
+			value={{
+				controls,
+				animation: currentAnimation.current,
+				loop,
+				loopDelay,
+			}}
+		>
+			{cloned}
+		</AnimateIconContext.Provider>
+	);
+}
+
+const pathClassName = "[&_[stroke-dasharray='1px_1px']]:![stroke-dasharray:1px_0px]";
+
+function IconWrapper<T extends string>({
+	size = 28,
+	animation: animationProp,
+	animate,
+	onAnimateChange,
+	animateOnHover = false,
+	animateOnTap = false,
+	icon: IconComponent,
+	loop = false,
+	loopDelay = 0,
+	onAnimateStart,
+	onAnimateEnd,
+	className,
+	...props
+}: IconWrapperProps<T>) {
+	const context = React.useContext(AnimateIconContext);
+
+	if (context) {
+		const { controls, animation: parentAnimation, loop: parentLoop, loopDelay: parentLoopDelay } = context;
+		const animationToUse = animationProp ?? parentAnimation;
+		const loopToUse = loop || parentLoop;
+		const loopDelayToUse = loopDelay || parentLoopDelay;
+
+		return (
+			<AnimateIconContext.Provider
+				value={{
+					controls,
+					animation: animationToUse,
+					loop: loopToUse,
+					loopDelay: loopDelayToUse,
+				}}
+			>
+				<IconComponent
+					size={size}
+					className={cn(className, (animationToUse === "path" || animationToUse === "path-loop") && pathClassName)}
+					{...props}
+				/>
+			</AnimateIconContext.Provider>
+		);
+	}
+
+	if (animate !== undefined || onAnimateChange !== undefined || animateOnHover || animateOnTap || animationProp) {
+		return (
+			<AnimateIcon
+				animate={animate}
+				onAnimateChange={onAnimateChange}
+				animateOnHover={animateOnHover}
+				animateOnTap={animateOnTap}
+				animation={animationProp}
+				loop={loop}
+				loopDelay={loopDelay}
+				onAnimateStart={onAnimateStart}
+				onAnimateEnd={onAnimateEnd}
+			>
+				<IconComponent
+					size={size}
+					className={cn(className, (animationProp === "path" || animationProp === "path-loop") && pathClassName)}
+					{...props}
+				/>
+			</AnimateIcon>
+		);
+	}
+
+	return (
+		<IconComponent
+			size={size}
+			className={cn(className, (animationProp === "path" || animationProp === "path-loop") && pathClassName)}
+			{...props}
+		/>
+	);
+}
+
+function getVariants<V extends { default: T; [key: string]: T }, T extends Record<string, Variants>>(animations: V): T {
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const { animation: animationType, loop, loopDelay } = useAnimateIconContext();
+
+	let result: T;
+
+	if (animationType in staticAnimations) {
+		const variant = staticAnimations[animationType as StaticAnimations];
+		result = {} as T;
+		for (const key in animations.default) {
+			if ((animationType === "path" || animationType === "path-loop") && key.includes("group")) continue;
+			result[key] = variant as T[Extract<keyof T, string>];
+		}
+	} else {
+		result = (animations[animationType as keyof V] as T) ?? animations.default;
+	}
+
+	if (loop) {
+		for (const key in result) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const state = result[key] as any;
+			const transition = state.animate?.transition;
+			if (!transition) continue;
+
+			const hasNestedKeys = Object.values(transition).some(
+				v => typeof v === "object" && v !== null && ("ease" in v || "duration" in v || "times" in v)
+			);
+
+			if (hasNestedKeys) {
+				for (const prop in transition) {
+					const subTrans = transition[prop];
+					if (typeof subTrans === "object" && subTrans !== null) {
+						transition[prop] = {
+							...subTrans,
+							repeat: Infinity,
+							repeatType: "loop",
+							repeatDelay: loopDelay,
+						};
+					}
+				}
+			} else {
+				state.animate.transition = {
+					...transition,
+					repeat: Infinity,
+					repeatType: "loop",
+					repeatDelay: loopDelay,
+				};
+			}
+		}
+	}
+
+	return result;
+}
+
+export {
+	pathClassName,
+	staticAnimations,
+	AnimateIcon,
+	IconWrapper,
+	useAnimateIconContext,
+	getVariants,
+	type IconProps,
+	type IconWrapperProps,
+	type AnimateIconProps,
+	type AnimateIconContextValue,
+};

--- a/apps/web/components/animate-ui/icons/log-out.tsx
+++ b/apps/web/components/animate-ui/icons/log-out.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import { motion, type Variants } from "motion/react";
+
+import { getVariants, useAnimateIconContext, IconWrapper, type IconProps } from "@/components/animate-ui/icons/icon";
+
+type LogOutProps = IconProps<keyof typeof animations>;
+
+const animations = {
+	default: {
+		group: {
+			initial: {
+				x: 0,
+				transition: { duration: 0.3, ease: "easeInOut" },
+			},
+			animate: {
+				x: 2,
+				transition: { duration: 0.3, ease: "easeInOut" },
+			},
+		},
+		path1: {},
+		path2: {},
+		path3: {},
+	} satisfies Record<string, Variants>,
+	"default-loop": {
+		group: {
+			initial: {
+				x: 0,
+			},
+			animate: {
+				x: [0, 2, 0],
+				transition: { duration: 0.6, ease: "easeInOut" },
+			},
+		},
+		path1: {},
+		path2: {},
+		path3: {},
+	} satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: LogOutProps) {
+	const { controls } = useAnimateIconContext();
+	const variants = getVariants(animations);
+
+	return (
+		<motion.svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<motion.g variants={variants.group} initial="initial" animate={controls}>
+				<motion.path d="m16 17 5-5-5-5" variants={variants.path1} initial="initial" animate={controls} />
+				<motion.path d="M21 12H9" variants={variants.path2} initial="initial" animate={controls} />
+			</motion.g>
+			<motion.path
+				d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"
+				variants={variants.path3}
+				initial="initial"
+				animate={controls}
+			/>
+		</motion.svg>
+	);
+}
+
+function LogOut(props: LogOutProps) {
+	return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export { animations, LogOut, LogOut as LogOutIcon, type LogOutProps, type LogOutProps as LogOutIconProps };

--- a/apps/web/components/animate-ui/icons/message-circle-question.tsx
+++ b/apps/web/components/animate-ui/icons/message-circle-question.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import * as React from "react";
+import { motion, type Variants } from "motion/react";
+
+import { getVariants, useAnimateIconContext, IconWrapper, type IconProps } from "@/components/animate-ui/icons/icon";
+
+type MessageCircleQuestionProps = IconProps<keyof typeof animations>;
+
+const animations = {
+	default: {
+		group: {
+			initial: {
+				rotate: 0,
+			},
+			animate: {
+				transformOrigin: "bottom left",
+				rotate: [0, 8, -8, 2, 0],
+				transition: {
+					ease: "easeInOut",
+					duration: 0.8,
+					times: [0, 0.4, 0.6, 0.8, 1],
+				},
+			},
+		},
+		path1: {},
+		path2: {
+			initial: {
+				y: 0,
+			},
+			animate: {
+				y: [0, 1, -0.25, 0],
+				transition: {
+					ease: "easeInOut",
+					duration: 0.8,
+					times: [0, 0.4, 0.7, 1],
+				},
+			},
+		},
+		path3: {},
+	} satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: MessageCircleQuestionProps) {
+	const { controls } = useAnimateIconContext();
+	const variants = getVariants(animations);
+
+	return (
+		<motion.svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<motion.g variants={variants.group} initial="initial" animate={controls}>
+				<motion.path
+					d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"
+					variants={variants.path1}
+					initial="initial"
+					animate={controls}
+				/>
+				<motion.path
+					d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+					variants={variants.path2}
+					initial="initial"
+					animate={controls}
+				/>
+				<motion.path d="M12 17h.01" variants={variants.path3} initial="initial" animate={controls} />
+			</motion.g>
+		</motion.svg>
+	);
+}
+
+function MessageCircleQuestion(props: MessageCircleQuestionProps) {
+	return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+	animations,
+	MessageCircleQuestion,
+	MessageCircleQuestion as MessageCircleQuestionIcon,
+	type MessageCircleQuestionProps,
+	type MessageCircleQuestionProps as MessageCircleQuestionIconProps,
+};

--- a/apps/web/components/animate-ui/icons/settings.tsx
+++ b/apps/web/components/animate-ui/icons/settings.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import { motion, type Variants } from "motion/react";
+
+import { getVariants, useAnimateIconContext, IconWrapper, type IconProps } from "@/components/animate-ui/icons/icon";
+
+type SettingsProps = IconProps<keyof typeof animations>;
+
+const animations = {
+	default: {
+		group: {
+			initial: {
+				rotate: 0,
+			},
+			animate: {
+				rotate: [0, 90, 180],
+				transition: {
+					duration: 1.25,
+					ease: "easeInOut",
+				},
+			},
+		},
+		path: {},
+		circle: {},
+	} satisfies Record<string, Variants>,
+	"default-loop": {
+		group: {
+			initial: {
+				rotate: 0,
+			},
+			animate: {
+				rotate: [0, 90, 180, 270, 360],
+				transition: {
+					duration: 2.5,
+					ease: "easeInOut",
+					repeat: Infinity,
+					repeatType: "loop",
+				},
+			},
+		},
+		path: {},
+		circle: {},
+	} satisfies Record<string, Variants>,
+	rotate: {
+		group: {
+			initial: {
+				rotate: 0,
+			},
+			animate: {
+				rotate: 360,
+				transition: {
+					duration: 2,
+					ease: "linear",
+					repeat: Infinity,
+					repeatType: "loop",
+				},
+			},
+		},
+		path: {},
+		circle: {},
+	} satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: SettingsProps) {
+	const { controls } = useAnimateIconContext();
+	const variants = getVariants(animations);
+
+	return (
+		<motion.svg
+			xmlns="http://www.w3.org/2000/svg"
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			{...props}
+		>
+			<motion.g variants={variants.group} initial="initial" animate={controls}>
+				<motion.path
+					d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+					variants={variants.path}
+					initial="initial"
+					animate={controls}
+				/>
+				<motion.circle cx={12} cy={12} r={3} variants={variants.circle} initial="initial" animate={controls} />
+			</motion.g>
+		</motion.svg>
+	);
+}
+
+function Settings(props: SettingsProps) {
+	return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export { animations, Settings, Settings as SettingsIcon, type SettingsProps, type SettingsProps as SettingsIconProps };

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -1,4 +1,9 @@
-import { Bell, HelpCircle, Settings } from "lucide-react";
+import { AnimateIcon } from "@/components/animate-ui/icons/icon";
+import { Bell } from "@/components/animate-ui/icons/bell";
+import { MessageCircleQuestion } from "@/components/animate-ui/icons/message-circle-question";
+import { Search } from "lucide-react";
+import { Settings } from "@/components/animate-ui/icons/settings";
+import { LogOut } from "@/components/animate-ui/icons/log-out";
 
 import { ModeToggle } from "@/components/mode-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -14,7 +19,6 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { authClient } from "@/packages/auth/src/auth-client";
-import { LogOut, Search } from "lucide-react";
 import Link from "next/link";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { redirect } from "next/navigation";
@@ -57,15 +61,21 @@ export function Header() {
 				</div>
 				<div className="flex items-center gap-2">
 					<ModeToggle />
-					<Button variant="ghost" size="icon">
-						<HelpCircle className="h-5 w-5" />
-					</Button>
-					<Button variant="ghost" size="icon">
-						<Settings className="h-5 w-5" />
-					</Button>
-					<Button variant="ghost" size="icon">
-						<Bell className="h-5 w-5" />
-					</Button>
+					<AnimateIcon animateOnHover>
+						<Button variant="ghost" size="icon">
+							<MessageCircleQuestion className="h-5 w-5 text-muted-foreground" />
+						</Button>
+					</AnimateIcon>
+					<AnimateIcon animateOnHover>
+						<Button variant="ghost" size="icon">
+							<Settings className="h-5 w-5 text-muted-foreground" />
+						</Button>
+					</AnimateIcon>
+					<AnimateIcon animateOnHover>
+						<Button variant="ghost" size="icon">
+							<Bell className="h-5 w-5 text-muted-foreground" />
+						</Button>
+					</AnimateIcon>
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" size="icon" className="rounded-full">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,7 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"lucide-react": "^0.511.0",
-		"motion": "^12.15.0",
+		"motion": "^12.16.0",
 		"next": "15.2.4",
 		"next-themes": "^0.4.6",
 		"react": "^19.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",
-        "motion": "^12.15.0",
+        "motion": "^12.16.0",
         "next": "15.2.4",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",


### PR DESCRIPTION
This PR standardizes all header icons to use our `AnimateIcon` wrapper for hover-triggered animations, adds consistent `text-muted-foreground` styling, and reorders imports for clarity.

**Checklist:**  
- [x] All header icons now use `AnimateIcon` for hover animations  (except search)
- [x] Added `text-muted-foreground` to each icon for consistent styling (bit unnecessary change but keep you like it)
- [x] Reordered imports for readability and grouping of animate-ui icons