### PR TITLE
feat: enhance file browser with size formatting and add user profile Component

### DIFF
--- a/apps/web/src/components/file-browser/file-browser-data.tsx
+++ b/apps/web/src/components/file-browser/file-browser-data.tsx
@@ -10,6 +10,7 @@ import { FileText, Folder, MoreVertical } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import type { FileItem } from "@/lib/types";
+import { fileSize } from "@/lib/utils";
 import Link from "next/link";
 
 // TODO: Typing of the file data needs to be updated
@@ -33,6 +34,7 @@ function FilesList({ data }: { data: FileItem[] }) {
 				</thead>
 				<tbody>
 					{data.map(file => {
+						const size = file.size ? fileSize(file.size) : "—";
 						const params = new URLSearchParams(searchParams.toString());
 						params.set("id", file.id);
 
@@ -48,7 +50,7 @@ function FilesList({ data }: { data: FileItem[] }) {
 									{file.name}
 								</td>
 								<td className="text-muted-foreground p-3 text-sm">{file.modified}</td>
-								<td className="text-muted-foreground p-3 text-sm">{file.size || "—"}</td>
+								<td className="text-muted-foreground p-3 text-sm">{size}</td>
 								<td className="p-3">
 									<FileActions id={file.id} />
 								</td>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -7,7 +7,6 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Bell, LogOut, MessageCircleQuestion, Search, Settings } from "lucide-react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SearchDialog } from "@/components/search/search-dialog";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { authClient } from "@nimbus/auth/auth-client";
@@ -15,19 +14,9 @@ import { ModeToggle } from "@/components/mode-toggle";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useSignOut } from "@/hooks/useAuth";
+import Profile from "./user-profile";
 import { useState } from "react";
 import Link from "next/link";
-
-const getInitials = (name?: string | null) => {
-	if (!name) return "SG";
-	const parts = name.trim().split(/\s+/);
-	if (parts.length === 0) return "SG";
-
-	const firstInitial = parts[0]?.[0] || "";
-	const lastInitial = parts.length > 1 ? parts[parts.length - 1]?.[0] || "" : "";
-
-	return (firstInitial + lastInitial).toUpperCase() || "SG";
-};
 
 export function Header() {
 	const { data: session, isPending } = authClient.useSession();
@@ -42,8 +31,6 @@ export function Header() {
 	const userEmail = session?.user?.email;
 	// TODO: Cache the user image
 	const userImage = session?.user?.image;
-	const userInitials = getInitials(userName);
-
 	return (
 		<header className="bg-background border-b">
 			<div className="flex h-16 items-center justify-between gap-4 px-4">
@@ -76,10 +63,7 @@ export function Header() {
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" size="icon" className="cursor-pointer rounded-full">
-								<Avatar className="h-8 w-8">
-									{userImage && <AvatarImage src={userImage} alt={userName || "User"} />}
-									<AvatarFallback>{isPending ? "..." : userInitials}</AvatarFallback>
-								</Avatar>
+								<Profile url={userImage || null} name={userName || ""} size="sm" />
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end">

--- a/apps/web/src/components/home/header.tsx
+++ b/apps/web/src/components/home/header.tsx
@@ -6,10 +6,18 @@ import { Discord } from "@/components/icons/discord";
 import Logo from "@/components/icons/brand/logo";
 import { XPlatform } from "@/components/icons/x";
 import { Button } from "@/components/ui/button";
+import { usePathname } from "next/navigation";
 import { Users } from "lucide-react";
 import Link from "next/link";
 
 export default function Header() {
+	const pathname = usePathname();
+	const isApp = pathname.startsWith("/app");
+
+	if (isApp) {
+		return null;
+	}
+
 	return (
 		<header className="absolute top-0 right-0 left-0 z-50 flex items-center justify-between p-4">
 			<h1 className="flex items-center gap-2 font-sans text-lg font-bold">

--- a/apps/web/src/components/home/header.tsx
+++ b/apps/web/src/components/home/header.tsx
@@ -6,18 +6,10 @@ import { Discord } from "@/components/icons/discord";
 import Logo from "@/components/icons/brand/logo";
 import { XPlatform } from "@/components/icons/x";
 import { Button } from "@/components/ui/button";
-import { usePathname } from "next/navigation";
 import { Users } from "lucide-react";
 import Link from "next/link";
 
 export default function Header() {
-	const pathname = usePathname();
-	const isApp = pathname.startsWith("/app");
-
-	if (isApp) {
-		return null;
-	}
-
 	return (
 		<header className="absolute top-0 right-0 left-0 z-50 flex items-center justify-between p-4">
 			<h1 className="flex items-center gap-2 font-sans text-lg font-bold">

--- a/apps/web/src/components/user-profile.tsx
+++ b/apps/web/src/components/user-profile.tsx
@@ -1,0 +1,48 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const iconvVariants = cva("rounded-full border flex items-center justify-center", {
+	variants: {
+		size: {
+			default: "!size-8 min-w-8 rounded-full",
+			sm: "!size-10 min-w-10 rounded-full",
+			lg: "!size-12 min-w-12 rounded-full",
+		},
+	},
+	defaultVariants: {
+		size: "default",
+	},
+});
+
+interface ProfileProps extends VariantProps<typeof iconvVariants> {
+	className?: string;
+	url: string | null;
+	name: string;
+}
+
+const getInitials = (name?: string | null) => {
+	if (!name) return "SG";
+	const parts = name.trim().split(/\s+/);
+	if (parts.length === 0) return "SG";
+
+	const firstInitial = parts[0]?.[0] || "";
+	const lastInitial = parts.length > 1 ? parts[parts.length - 1]?.[0] || "" : "";
+
+	return (firstInitial + lastInitial).toUpperCase() || "SG";
+};
+
+const Profile = ({ className, url, name, size }: ProfileProps) => {
+	const initials = getInitials(name);
+
+	return (
+		<Avatar className={cn(iconvVariants({ size }), className)}>
+			<AvatarImage src={url as string} />
+			<AvatarFallback className="rounded-md bg-gray-100 text-sm font-semibold text-gray-500">{initials}</AvatarFallback>
+		</Avatar>
+	);
+};
+
+export default Profile;

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }
+
+export function fileSize(size: unknown) {
+	let num = typeof size === "number" ? size : Number(size);
+	if (typeof num !== "number" || isNaN(num) || num < 0) {
+		return "Invalid size";
+	}
+	const units = ["B", "KB", "MB", "GB", "TB"];
+	let idx = 0;
+	while (num >= 1024 && idx < units.length - 1) {
+		num /= 1024;
+		idx++;
+	}
+	return `${num.toFixed(idx === 0 ? 0 : 2)} ${units[idx]}`;
+}


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings across multiple components to improve functionality and maintainability. The key changes include adding a utility function for file size formatting, refactoring the user profile handling in the header, and optimizing the display logic for the app header on specific routes.

### File Browser Enhancements:
* Added a `fileSize` utility function in `apps/web/src/lib/utils.ts` to format file sizes into human-readable units. This function is now used in the `FilesList` component to display file sizes consistently. (`[[1]](diffhunk://#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767R7-R20)`, `[[2]](diffhunk://#diff-796ed0682ad34b2ab36d8d477cabb8d80e33588f9995fce61d73ba69cb563ce5R13)`, `[[3]](diffhunk://#diff-796ed0682ad34b2ab36d8d477cabb8d80e33588f9995fce61d73ba69cb563ce5R37)`, `[[4]](diffhunk://#diff-796ed0682ad34b2ab36d8d477cabb8d80e33588f9995fce61d73ba69cb563ce5L51-R53)`)

### Header Refactor:
* Replaced the inline avatar logic in `apps/web/src/components/header.tsx` with a new reusable `Profile` component, which handles user initials, fallback, and avatar image. The `Profile` component is defined in `apps/web/src/components/user-profile.tsx`. (`[[1]](diffhunk://#diff-52fcdcdf38835ab718a83237d90f42a60b5bedb392e7417721a84e1cd3a4cee9L10-L31)`, `[[2]](diffhunk://#diff-52fcdcdf38835ab718a83237d90f42a60b5bedb392e7417721a84e1cd3a4cee9L45-L46)`, `[[3]](diffhunk://#diff-52fcdcdf38835ab718a83237d90f42a60b5bedb392e7417721a84e1cd3a4cee9L79-R66)`, `[[4]](diffhunk://#diff-732a8e2d3ed1cce389fe51184c3d2531edc06e49082ed73289dff0d6f7d8acd2R1-R48)`)

### App Header Optimization:
* Updated the `Header` component in `apps/web/src/components/home/header.tsx` to conditionally render based on the current route. If the pathname starts with `/app`, the header is hidden. (`[apps/web/src/components/home/header.tsxR9-R20](diffhunk://#diff-6541822adf4f942735e1cb52e71f4de7d162171b4cf069863aae3c3fe28f49bcR9-R20)`)