### PR TITLE
fix(avatar): prevent hydration mismatch by rendering initials only on…

### DIFF
--- a/apps/web/src/components/user-profile.tsx
+++ b/apps/web/src/components/user-profile.tsx
@@ -37,10 +37,17 @@ const getInitials = (name?: string | null) => {
 const Profile = ({ className, url, name, size }: ProfileProps) => {
 	const initials = getInitials(name);
 
+	const [isClient, setIsClient] = React.useState(false);
+	React.useEffect(() => {
+		setIsClient(true);
+	}, []);
+
 	return (
 		<Avatar className={cn(iconvVariants({ size }), className)}>
 			<AvatarImage src={url as string} />
-			<AvatarFallback className="rounded-md bg-gray-100 text-sm font-semibold text-gray-500">{initials}</AvatarFallback>
+			<AvatarFallback className="rounded-md bg-gray-100 text-sm font-semibold text-gray-500">
+				{isClient ? initials : ""}
+			</AvatarFallback>
 		</Avatar>
 	);
 };


### PR DESCRIPTION
This wasn't a serious problem, but it was annoying. 