### PR TITLE
fix: update Dropbox test mocks for improved error handling

### DIFF
--- a/apps/server/src/providers/dropbox/tests/dropbox-provider.test.ts
+++ b/apps/server/src/providers/dropbox/tests/dropbox-provider.test.ts
@@ -151,7 +151,17 @@ describe("DropboxProvider", () => {
 		});
 
 		it("should return null when file not found", async () => {
-			mockDropboxClient.filesGetMetadata.mockRejectedValue(new Error("Not found"));
+			const notFoundError = {
+				error: {
+					error: {
+						".tag": "path",
+						path: {
+							".tag": "not_found",
+						},
+					},
+				},
+			};
+			mockDropboxClient.filesGetMetadata.mockRejectedValue(notFoundError);
 
 			const result = await provider.getById("/nonexistent.txt");
 
@@ -293,7 +303,17 @@ describe("DropboxProvider", () => {
 		});
 
 		it("should return null on download error", async () => {
-			mockDropboxClient.filesDownload.mockRejectedValue(new Error("Download failed"));
+			const notFoundError = {
+				error: {
+					error: {
+						".tag": "path",
+						path: {
+							".tag": "not_found",
+						},
+					},
+				},
+			};
+			mockDropboxClient.filesDownload.mockRejectedValue(notFoundError);
 
 			const result = await provider.download("/test-file.txt");
 


### PR DESCRIPTION
Fixes failing Dropbox provider tests by updating mock error structures to match the improved error handling that only returns null for 'not found' errors and re-throws other errors.

## Changes
- Updated test mocks to use proper Dropbox API error structure for not found errors
- All 36 Dropbox provider tests now pass

Fixes test failures found during staging branch merge.